### PR TITLE
Add automatic opening for HTML output

### DIFF
--- a/cmd/tube-designer/main.go
+++ b/cmd/tube-designer/main.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -149,4 +151,28 @@ func main() {
 
 	// 6. Print results
 	printResults(tubing, stockIn, kerfIn, cuts, solution)
+
+	// Also generate an HTML version for the operator
+	htmlFile := "cut_plan.html"
+	if err := generateHTML(htmlFile, tubing, stockIn, kerfIn, cuts, solution); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write HTML output: %v\n", err)
+	} else {
+		fmt.Printf("HTML output written to %s\n", htmlFile)
+		if err := openFile(htmlFile); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to open HTML file: %v\n", err)
+		}
+	}
+}
+
+func openFile(name string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", name)
+	case "darwin":
+		cmd = exec.Command("open", name)
+	default:
+		cmd = exec.Command("xdg-open", name)
+	}
+	return cmd.Start()
 }

--- a/cmd/tube-designer/output.go
+++ b/cmd/tube-designer/output.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"html/template"
 	"math"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -126,4 +128,190 @@ func plural(n int) string {
 		return ""
 	}
 	return "s"
+}
+
+// Pattern groups sticks with identical cuts
+type Pattern struct {
+	Cuts     []Cut
+	Count    int
+	UsedLen  int
+	WasteLen int
+}
+
+// groupPatterns combines sticks that have the same sequence of cuts
+func groupPatterns(sticks []Stick) []Pattern {
+	m := make(map[string]*Pattern)
+	for _, s := range sticks {
+		var parts []string
+		for _, c := range s.Cuts {
+			parts = append(parts, fmt.Sprintf("%d", c.Length))
+		}
+		key := strings.Join(parts, "-")
+
+		if p, ok := m[key]; ok {
+			p.Count++
+		} else {
+			m[key] = &Pattern{
+				Cuts:     s.Cuts,
+				Count:    1,
+				UsedLen:  s.UsedLen,
+				WasteLen: s.WasteLen,
+			}
+		}
+	}
+
+	patterns := make([]Pattern, 0, len(m))
+	for _, p := range m {
+		patterns = append(patterns, *p)
+	}
+
+	sort.Slice(patterns, func(i, j int) bool {
+		if patterns[i].Count == patterns[j].Count {
+			return patterns[i].UsedLen < patterns[j].UsedLen
+		}
+		return patterns[i].Count > patterns[j].Count
+	})
+
+	return patterns
+}
+
+// generateHTML writes a printable HTML file summarizing the solution
+func generateHTML(filename, tubing string, stockLen int, kerf float64, cuts []Cut, solution Solution) error {
+	type cutInstr struct {
+		Mark string
+		Len  string
+	}
+
+	type patternData struct {
+		Count   int
+		CutList string
+		Used    string
+		Waste   string
+		Instr   []cutInstr
+	}
+
+	type pageData struct {
+		Date       string
+		Tubing     string
+		Stock      string
+		Kerf       string
+		TotalStock string
+		TotalWaste string
+		Efficiency string
+		AvgWaste   string
+		Patterns   []patternData
+	}
+
+	kerfInt := int(math.Ceil(kerf * 1000))
+	patterns := groupPatterns(solution.Sticks)
+
+	var patData []patternData
+	for _, p := range patterns {
+		var cutStrs []string
+		for _, c := range p.Cuts {
+			cutStrs = append(cutStrs, prettyLen(c.Length))
+		}
+		cutList := strings.Join(cutStrs, ", ")
+
+		runningLen := 0
+		var instr []cutInstr
+		for i, c := range p.Cuts {
+			if i > 0 {
+				runningLen += kerfInt / 1000
+			}
+			markAt := runningLen + c.Length
+			instr = append(instr, cutInstr{
+				Mark: prettyLen(markAt),
+				Len:  prettyLen(c.Length),
+			})
+			runningLen = markAt
+		}
+
+		patData = append(patData, patternData{
+			Count:   p.Count,
+			CutList: cutList,
+			Used:    prettyLen(p.UsedLen),
+			Waste:   prettyLen(p.WasteLen),
+			Instr:   instr,
+		})
+	}
+
+	totalStock := solution.NumSticks * stockLen
+	efficiency := float64(totalStock-solution.TotalWaste) / float64(totalStock) * 100
+
+	data := pageData{
+		Date:       time.Now().Format("2006-01-02"),
+		Tubing:     tubing,
+		Stock:      prettyLen(stockLen),
+		Kerf:       fmt.Sprintf("%.4f\"", kerf),
+		TotalStock: prettyLen(totalStock),
+		TotalWaste: prettyLen(solution.TotalWaste),
+		Efficiency: fmt.Sprintf("%.1f", efficiency),
+		AvgWaste:   prettyLen(solution.TotalWaste / solution.NumSticks),
+		Patterns:   patData,
+	}
+
+	const tpl = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Cut Plan</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        h1, h2, h3 { color: #333; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+<h1>Cut Plan</h1>
+<p>Date: {{.Date}}</p>
+<p>Material: {{.Tubing}} @ {{.Stock}}</p>
+<p>Kerf: {{.Kerf}}</p>
+
+<h2>Efficiency Summary</h2>
+<ul>
+    <li>Total stock used: {{.TotalStock}}</li>
+    <li>Total waste: {{.TotalWaste}}</li>
+    <li>Material efficiency: {{.Efficiency}}%</li>
+    <li>Average waste per stick: {{.AvgWaste}}</li>
+</ul>
+
+<h2>Cut Patterns</h2>
+<table>
+    <tr><th>Qty</th><th>Cuts</th><th>Used</th><th>Waste</th></tr>
+    {{range .Patterns}}
+    <tr>
+        <td>{{.Count}}</td>
+        <td>{{.CutList}}</td>
+        <td>{{.Used}}</td>
+        <td>{{.Waste}}</td>
+    </tr>
+    {{end}}
+</table>
+
+{{range $idx, $p := .Patterns}}
+<h3>Pattern {{$idx | inc}} – Qty {{$p.Count}}</h3>
+<table>
+    <tr><th>#</th><th>Mark At</th><th>Cut Piece</th></tr>
+    {{range $i, $c := $p.Instr}}
+    <tr><td>{{$i | inc}}</td><td>{{$c.Mark}}</td><td>{{$c.Len}}</td></tr>
+    {{end}}
+    <tr><td colspan="3">Remaining: {{$p.Waste}}</td></tr>
+</table>
+{{end}}
+
+</body>
+</html>`
+
+	t := template.Must(template.New("page").Funcs(template.FuncMap{"inc": func(i int) int { return i + 1 }}).Parse(tpl))
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return t.Execute(f, data)
 }


### PR DESCRIPTION
## Summary
- automatically open the generated `cut_plan.html` when HTML output is created

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843374f18808323bf875a27c73301bb