### PR TITLE
Add parse unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,13 @@ run: all
 test: all
 	./$(TARGET) --test
 
+# Build and run unit tests for parser utilities
+tests/parse_test: tests/parse_test.cpp parse.cpp parse.h
+	$(CXX) -std=c++17 -Wall -Wextra -I. tests/parse_test.cpp parse.cpp -o $@
+
+parse-test: tests/parse_test
+	./tests/parse_test
+
 # Target to clean the build directory of generated files
 clean:
 	@echo "Cleaning..."
@@ -87,5 +94,5 @@ clean:
 
 # Phony targets are commands that are not actual files.
 # This prevents 'make' from getting confused if a file named 'clean' exists.
-.PHONY: all clean run test
+.PHONY: all clean run test parse-test
 

--- a/tests/parse_test.cpp
+++ b/tests/parse_test.cpp
@@ -1,0 +1,23 @@
+#include "parse.h"
+#include <cassert>
+#include <cmath>
+
+int main() {
+    // parseAdvancedLength tests
+    assert(parseAdvancedLength("24'") == 288);
+    assert(parseAdvancedLength("288") == 288);
+    assert(parseAdvancedLength("20' 6\"") == 246);
+    assert(parseAdvancedLength("7'6 1/2\"") == 91);
+    assert(parseAdvancedLength("180 1/2") == 181);
+    assert(parseAdvancedLength("8'4\"") == 100);
+    assert(parseAdvancedLength("bad") == 0);
+
+    // parseFraction tests
+    assert(std::abs(parseFraction("1/2") - 0.5) < 1e-6);
+    assert(std::abs(parseFraction("0.125") - 0.125) < 1e-6);
+    assert(std::abs(parseFraction("3/16") - 0.1875) < 1e-6);
+    assert(std::abs(parseFraction(" 3 / 6 ") - 0.5) < 1e-6);
+    assert(parseFraction("junk") == 0.0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add minimal parse tests
- support building test in Makefile

## Testing
- `make parse-test`
- `make test` *(fails: Highs.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68460f3075908323b273cc2e4165e954